### PR TITLE
add debug console logger

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -121,13 +121,20 @@ LOGGING = {
         'mail_admins': {
             'level': 'ERROR',
             'class': 'django.utils.log.AdminEmailHandler'
-        }
+        },
+        'console': {
+            'class':'logging.StreamHandler',
+        },
     },
     'loggers': {
         'django.request': {
             'handlers': ['mail_admins'],
             'level': 'ERROR',
             'propagate': True,
+        },
+        'django': {
+            'handlers': ['console'],
+            'level': 'DEBUG',
         },
     }
 }


### PR DESCRIPTION
Add logger to log everything to console. This makes it much easier to
see error stack traces.

If you take this, on production we may want to consider having a local_settings.py that configures the loggers to be less chatty.
