### PR TITLE
Implement "More than x emails opened"

### DIFF
--- a/search/templates/home.html
+++ b/search/templates/home.html
@@ -282,6 +282,12 @@ console.log(anchor);
 
   <input
      type="text"
+     id="template_emails_opened"
+     name="emails_opened"
+     />
+
+  <input
+     type="text"
      id="template_contacted_since"
      name="contacted_since"
      data-paired-with="contacted_by"

--- a/search/templates/home.html
+++ b/search/templates/home.html
@@ -284,19 +284,27 @@ console.log(anchor);
      type="text"
      id="template_emails_opened"
      name="emails_opened"
+     data-paired-with="emails_opened__since"
+     />
+
+  <input
+     type="text"
+     id="template_emails_opened__since"
+     name="emails_opened__since"
+     placeholder="MM/DD/YYYY"
      />
 
   <input
      type="text"
      id="template_contacted_since"
      name="contacted_since"
-     data-paired-with="contacted_by"
+     data-paired-with="contacted_since__contacted_by"
      placeholder="MM/DD/YYYY"
      />
 
   <input type="text"
-	 id="template_contacted_by"
-	 name="contacted_by"
+	 id="template_contacted_since__contacted_by"
+	 name="contacted_since__contacted_by"
 	 placeholder="Contacted by:"
 	 />
 
@@ -304,14 +312,14 @@ console.log(anchor);
      id="template_zipcode"
      type="text"
      name="zipcode"
-     data-paired-with="distance"
+     data-paired-with="zipcode__distance"
      placeholder="Zip Code"
      />
 
   <input
-     id="template_distance"
+     id="template_zipcode__distance"
      type="text"
-     name="distance"
+     name="zipcode__distance"
      style="margin-left: 10px"
      placeholder="Distance in miles"
      />

--- a/search/views.py
+++ b/search/views.py
@@ -92,9 +92,11 @@ def make_contact_history_query(users, query_data, values, search_on, extra_data=
 
 def make_emails_opened_query(users, query_data, values, search_on, extra_data={}):
     num_opens = values[0]
-    search = """        
-SELECT count(distinct mailing_id) from core_open where core_open.user_id=core_user.id) > 30;
-"""
+    num_opens = int(num_opens)
+    return (users.extra(where=["(SELECT COUNT(DISTINCT `mailing_id`) FROM `core_open`" 
+                               " WHERE `core_open`.`user_id`=`core_user`.`id`)" 
+                               " > %s" % num_opens]),
+            "emails opened > %s" % num_opens)
 
 QUERIES = {
     'country': {
@@ -249,6 +251,7 @@ def home(request):
              ('source', 'Source'),
              ('tag', 'Is tagged with'),
              ('contacted_since', "Contacted Since"),
+             ('emails_opened', "Emails Opened"),
              ),
         'About':
             (('organization', "Organization"),

--- a/search/views.py
+++ b/search/views.py
@@ -93,10 +93,18 @@ def make_contact_history_query(users, query_data, values, search_on, extra_data=
 def make_emails_opened_query(users, query_data, values, search_on, extra_data={}):
     num_opens = values[0]
     num_opens = int(num_opens)
+    if 'since' in extra_data:
+        since = dateutil.parser.parse(extra_data['since'])
+        return (users.extra(where=["(SELECT COUNT(DISTINCT `mailing_id`) FROM `core_open`" +
+                                   " WHERE `core_open`.`user_id`=`core_user`.`id`" +
+                                   " AND `core_open`.`created_at` >= \"%s\")" % since +
+                                   " >= %s" % num_opens]),
+                "opened at least %s emails since %s" % (num_opens, since))
+
     return (users.extra(where=["(SELECT COUNT(DISTINCT `mailing_id`) FROM `core_open`" 
                                " WHERE `core_open`.`user_id`=`core_user`.`id`)" 
-                               " > %s" % num_opens]),
-            "emails opened > %s" % num_opens)
+                               " >= %s" % num_opens]),
+            "opened at least %s emails" % num_opens)
 
 QUERIES = {
     'country': {
@@ -339,10 +347,10 @@ def _search(request):
         _human_query = []
         for item in include_group[1]:
             ## "distance" is handled in a group with "zipcode", so we ignore it here
-            if item == "distance":
+            if item == "zipcode__distance":
                 continue
             ## same for "contacted_by", in a group with "contacted_since"
-            if item == "contacted_by":
+            if item == "contacted_since__contacted_by":
                 continue
 
             possible_values = request.GET.getlist(
@@ -356,7 +364,7 @@ def _search(request):
             # these two fields are together, if we have another case like this
             # we should probably formalize this
             if item == "zipcode":
-                distance = request.GET.get('%s_distance' % include_group[0])
+                distance = request.GET.get('%s_zipcode__distance' % include_group[0])
                 if distance:
                     extra_data['distance'] = distance
 
@@ -364,9 +372,14 @@ def _search(request):
             # these two fields are together, if we have another case like this
             # we should probably formalize this
             if item == "contacted_since":
-                contacted_by = request.GET.get('%s_contacted_by' % include_group[0])
+                contacted_by = request.GET.get('%s_contacted_since__contacted_by' % include_group[0])
                 if contacted_by:
                     extra_data['contacted_by'] = contacted_by
+
+            if item == "emails_opened":
+                since = request.GET.get('%s_emails_opened__since' % include_group[0])
+                if since:
+                    extra_data['since'] = since
 
             make_query_fn = query_data.get('query_fn', make_default_user_query)
             users, __human_query = make_query_fn(users, query_data, possible_values, item, extra_data)


### PR DESCRIPTION
The primary change here is implementing a search option for "at least X emails opened [since mm/dd/yyyy]" using `users.extra(where=..)` with subqueries in the WHERE clause like 

  WHERE (SELECT COUNT(DISTINCT `mailing_id`) FROM `core_open` 
                   WHERE `core_open`.`user_id`=`core_user`.`id`
                   AND `core_open`.`created_at` >= {{ some datetime }})
     >= {{ some number }}`

In addition, this branch also inches a little further toward formalization of the "composite query options" (X emails opened since Y; contacted since A by B; within Q miles of Z) by using a double-underscore notation in the name of the "subordinate" option.  It's probably time to fully formalize this.

Lastly, this branch also modifies the `query_fn` contract.  Previously it returned a dict to be passed in to a `users = users.filter(**data)` operation.  It has now been modified to take in the `users` query and return a modified `users` query, so the `query_fn` is now responsible for calling the `.filter` itself if it wants to.  This gives us more flexibility to use other operations like `.extra()` instead of restricting ourselves to `.filter()` calls.
